### PR TITLE
gitter: init at 3.1.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gitter/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gitter/default.nix
@@ -1,0 +1,84 @@
+{ stdenv, fetchurl, dpkg, makeWrapper
+, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib
+, gnome2, libnotify, libxcb, nspr, nss, systemd, xorg }:
+
+let
+
+  version = "3.1.0";
+
+  rpath = stdenv.lib.makeLibraryPath [
+    alsaLib
+    atk
+    cairo
+    cups
+    curl
+    dbus
+    expat
+    fontconfig
+    freetype
+    glib
+    gnome2.GConf
+    gnome2.gdk_pixbuf
+    gnome2.gtk
+    gnome2.pango
+    libnotify
+    libxcb
+    nspr
+    nss
+    stdenv.cc.cc
+    systemd
+
+    xorg.libxkbfile
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libXScrnSaver
+  ] + ":${stdenv.cc.cc.lib}/lib64";
+
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://update.gitter.im/linux64/gitter_3.1.0_amd64.deb";
+        sha512 = "b2888a2c9ed399102e2e80a2ec1ffafe093bdbe2f11d74753052c14841201cf586e0bb2a42ff8e67517d000a7c0b6f6aed30c32b3a7ecc683a18f8433b0bfa1c";
+      }
+    else
+      throw "Gitter is not supported on ${stdenv.system}";
+
+in stdenv.mkDerivation {
+  name = "gitter-${version}";
+
+  inherit src;
+
+  dontBuild = true;
+  buildInputs = [ dpkg makeWrapper ];
+  
+  unpackPhase = ''
+    dpkg -x $src .
+  '';
+  
+  installPhase = ''
+    mkdir -p $out
+
+    cp -r ./opt/Gitter/linux64 $out
+
+    ls -lR $out
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$out/linux64/Gitter"
+    makeWrapper "$out/linux64/Gitter" "$out/bin/gitter" \
+      --prefix LD_LIBRARY_PATH : "${rpath}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Desktop client for Gitter";
+    homepage = https://gitter.im;
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15219,6 +15219,8 @@ with pkgs;
 
   gitolite = callPackage ../applications/version-management/gitolite { };
 
+  gitter = callPackage ../applications/networking/instant-messengers/gitter { };
+
   inherit (gnome3) gitg;
 
   giv = callPackage ../applications/graphics/giv { };


### PR DESCRIPTION
###### Motivation for this change

Adds the [Gitter](https://gitter.im/) desktop app.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fits CONTRIBUTING.md, except for a lack of maintainer.  I'm new to NixOS and unclear whether to add myself or seek someone more experienced.